### PR TITLE
FeatReg was not enabled by default

### DIFF
--- a/src/FeatureProcessing/FeatureRegister.hpp
+++ b/src/FeatureProcessing/FeatureRegister.hpp
@@ -51,7 +51,7 @@ class FeatureRegister {
   };
   enum WorkingMode { SYNC, LATCH };
   FeatureRegister() {
-    _state = DISABLED;
+    _state = WAITING;
     _mode = SYNC;
     _registered_rms = 0.0f;
   }

--- a/src/PluginProcessorGUI.cpp
+++ b/src/PluginProcessorGUI.cpp
@@ -338,9 +338,9 @@ juce::AudioProcessorValueTreeState::ParameterLayout createParameterLayout() {
       std::make_unique<juce::AudioParameterInt>(
           juce::ParameterID(IDs::debug7, 1), "Enable OSC", 0, 1, 0),
       std::make_unique<juce::AudioParameterInt>(
-          juce::ParameterID(IDs::debug8, 1), "Enable FeatReg", 0, 1, 1),
+          juce::ParameterID(IDs::debug8, 1), "Enable FeatReg", 0, 1, 1), //Should be engaged by default.
       std::make_unique<juce::AudioParameterInt>(
-          juce::ParameterID(IDs::debug9, 1), "FeatReg Mode", 0, 1, 0)); //Modes: {SYNC,LATCH}
+          juce::ParameterID(IDs::debug9, 1), "FeatReg Mode", 0, 1, 0)); //Default mode: SYNC
   
   layout.add(std::move(algorithm), std::move(ratios_dx),
             std::move(boost), std::move(gain), std::move(debug));


### PR DESCRIPTION
The Feature Register ensures that both F0 and RMS are synced when a note is detected. It is important to keep it this way to preserve transients. Users can tweak and disable it by modifying the extended settings.